### PR TITLE
Token validation: loose the constraints

### DIFF
--- a/lib/solarwinds_apm/support/service_key_checker.rb
+++ b/lib/solarwinds_apm/support/service_key_checker.rb
@@ -66,7 +66,7 @@ module SolarWindsAPM
     end
 
     def parse_service_key(service_key)
-      match = service_key.match(/([^:]+)(:{0,1})(.*)/)
+      match = service_key.match(/([^:]*)(:{0,1})(.*)/)
       return ['', '', ''] if match.nil?
 
       [match[1], match[2], match[3]]

--- a/test/solarwinds_apm/init_test/init_2_test.rb
+++ b/test/solarwinds_apm/init_test/init_2_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2024 SolarWinds, LLC.
+# All rights reserved.
+
+require 'initest_helper'
+
+describe 'solarwinds_apm_init_2' do
+  it 'SW_APM_SERVICE_KEY_is_invalid' do
+    puts "\n\033[1m=== TEST RUN: #{RUBY_VERSION} #{File.basename(__FILE__)} #{Time.now.strftime('%Y-%m-%d %H:%M')} ===\033[0m\n"
+
+    log_output = StringIO.new
+    SolarWindsAPM.logger = Logger.new(log_output)
+
+    ENV['SW_APM_REPORTER'] = 'ssl'
+    ENV['SW_APM_SERVICE_KEY'] = ':abcd'
+
+    require './lib/solarwinds_apm'
+    assert_includes log_output.string, 'SW_APM_SERVICE_KEY problem. API Token in wrong format'
+
+    noop_shared_test
+  end
+end

--- a/test/solarwinds_apm/oboe_init_options_test.rb
+++ b/test/solarwinds_apm/oboe_init_options_test.rb
@@ -222,7 +222,7 @@ describe 'OboeInitOptions' do
 
     SolarWindsAPM::Config[:service_key] = '22222222-2222-2222-2222-222222222222:service'
     SolarWindsAPM::OboeInitOptions.instance.re_init
-    _(SolarWindsAPM::OboeInitOptions.instance.service_key_ok?).must_equal false
+    _(SolarWindsAPM::OboeInitOptions.instance.service_key_ok?).must_equal true
 
     SolarWindsAPM::Config[:service_key] = 'CWoadXY66FXNd_e5u3nabLZ1KByYZRTi1yWJg2AcD6MHo1AA42UstbipfHfx6Hnl-821ARq'
     SolarWindsAPM::OboeInitOptions.instance.re_init
@@ -249,7 +249,7 @@ describe 'OboeInitOptions' do
 
     ENV['SW_APM_SERVICE_KEY'] = '22222222-2222-2222-2222-222222222222:service'
     SolarWindsAPM::OboeInitOptions.instance.re_init
-    _(SolarWindsAPM::OboeInitOptions.instance.service_key_ok?).must_equal false
+    _(SolarWindsAPM::OboeInitOptions.instance.service_key_ok?).must_equal true
 
     ENV['SW_APM_SERVICE_KEY'] = 'CWoadXY66FXNd_e5u3nabLZ1KByYZRTi1yWJg2AcD6MHo1AA42UstbipfHfx6Hnl-821ARq'
     SolarWindsAPM::OboeInitOptions.instance.re_init


### PR DESCRIPTION
### Description
1. modify the oboe_init_options_test.rb
2. change the pattern for regex

### Test (if applicable)
1. standard apm-ruby test case.
